### PR TITLE
Do not use the xvfb-fixture under Windows

### DIFF
--- a/multisensor_pipeline/tests/test_input.py
+++ b/multisensor_pipeline/tests/test_input.py
@@ -1,10 +1,30 @@
+import sys
 from time import sleep
 
 import pytest
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith('win32') or
+    sys.platform.startswith('cygwin'),
+    reason="Does not run under Windows.",
+)
 @pytest.mark.timeout(0.320 * 10)  # Kill runs taking 10x longer than local
-def test_simple_mouse(xvfb):
+def test_simple_mouse_not_windows(xvfb):
+    __test_simple_mouse()
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith('win32') and
+    not sys.platform.startswith('cygwin'),
+    reason="Does run only under Windows.",
+)
+@pytest.mark.timeout(0.320 * 10)  # Kill runs taking 10x longer than local
+def test_simple_mouse_windows():
+    __test_simple_mouse()
+
+
+def __test_simple_mouse():
     from multisensor_pipeline.modules import QueueSink
     from multisensor_pipeline.modules.mouse import Mouse
     from multisensor_pipeline.pipeline.graph import GraphPipeline
@@ -17,6 +37,7 @@ def test_simple_mouse(xvfb):
     pipeline = GraphPipeline()
     pipeline.add_source(source)
     pipeline.add_sink(sink)
+
     # (3) ...and connect the modules
     pipeline.connect(source, sink)
 
@@ -26,11 +47,31 @@ def test_simple_mouse(xvfb):
     pipeline.stop()
 
     # Assert
+    # If we ever get here, we consider this test successful.
     assert True
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith('win32') or
+    sys.platform.startswith('cygwin'),
+    reason="Does not run under Windows.",
+)
 @pytest.mark.timeout(0.420 * 10)  # Kill runs taking 10x longer than local
-def test_simple_keyboard(xvfb):
+def test_simple_keyboard_not_windows(xvfb):
+    __test_simple_keyboard()
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith('win32') and
+    not sys.platform.startswith('cygwin'),
+    reason="Does run only under Windows.",
+)
+@pytest.mark.timeout(0.420 * 10)  # Kill runs taking 10x longer than local
+def test_simple_keyboard_windows():
+    __test_simple_keyboard()
+
+
+def __test_simple_keyboard():
     from multisensor_pipeline.modules import QueueSink
     from multisensor_pipeline.modules.keyboard import Keyboard
     from multisensor_pipeline.pipeline.graph import GraphPipeline
@@ -44,6 +85,7 @@ def test_simple_keyboard(xvfb):
     pipeline = GraphPipeline()
     pipeline.add_source(source)
     pipeline.add_sink(sink)
+
     # (3) ...and connect the modules
     pipeline.connect(source, sink)
 

--- a/multisensor_pipeline/tests/test_profiling.py
+++ b/multisensor_pipeline/tests/test_profiling.py
@@ -18,7 +18,6 @@ class ProfilingTest(unittest.TestCase):
         for frame in frames:
             msp_stats.add_frame(frame, direction=MSPModuleStats.Direction.IN)
             sleep(1. / frequency)
-        sleep(1)  # To make this work under macOS in the cloud
 
         stats = msp_stats.get_stats(direction=MSPModuleStats.Direction.IN)
         self.assertAlmostEqual(frequency, stats["test"]._cma, delta=1)

--- a/multisensor_pipeline/tests/test_profiling.py
+++ b/multisensor_pipeline/tests/test_profiling.py
@@ -18,7 +18,7 @@ class ProfilingTest(unittest.TestCase):
         for frame in frames:
             msp_stats.add_frame(frame, direction=MSPModuleStats.Direction.IN)
             sleep(1. / frequency)
-        sleep(0.1)  # To make this work under macOS in the cloud
+        sleep(1)  # To make this work under macOS in the cloud
 
         stats = msp_stats.get_stats(direction=MSPModuleStats.Direction.IN)
         self.assertAlmostEqual(frequency, stats["test"]._cma, delta=1)

--- a/multisensor_pipeline/tests/test_profiling.py
+++ b/multisensor_pipeline/tests/test_profiling.py
@@ -18,6 +18,7 @@ class ProfilingTest(unittest.TestCase):
         for frame in frames:
             msp_stats.add_frame(frame, direction=MSPModuleStats.Direction.IN)
             sleep(1. / frequency)
+        sleep(0.1)  # To make this work under macOS in the cloud
 
         stats = msp_stats.get_stats(direction=MSPModuleStats.Direction.IN)
         self.assertAlmostEqual(frequency, stats["test"]._cma, delta=1)

--- a/multisensor_pipeline/tests/test_signal.py
+++ b/multisensor_pipeline/tests/test_signal.py
@@ -30,6 +30,7 @@ class DownsamplingProcessorTest(unittest.TestCase):
         pipeline.add_source(source)
         pipeline.add_processor(processor)
         pipeline.add_sink(sink_1)
+
         # (3) ...and connect the modules
         pipeline.connect(source, sink_0)
         pipeline.connect(source, processor)
@@ -40,6 +41,8 @@ class DownsamplingProcessorTest(unittest.TestCase):
         sleep(2)
         pipeline.stop()
         pipeline.join()
+
+        sleep(0.1)  # To make this work under macOS in the cloud
 
         # Assert
         self.assertEqual(num_samples, sink_0.queue.qsize())
@@ -63,6 +66,7 @@ class DownsamplingProcessorTest(unittest.TestCase):
         pipeline.add_source(source)
         pipeline.add_processor(processor)
         pipeline.add_sink(sink)
+
         # (3) ...and connect the modules
         pipeline.connect(source, processor)
         pipeline.connect(processor, sink)
@@ -72,6 +76,8 @@ class DownsamplingProcessorTest(unittest.TestCase):
         sleep(1)
         pipeline.stop()
         pipeline.join()
+
+        sleep(0.1)  # To make this work under macOS in the cloud
 
         # Assert
         assert sink.queue.qsize() <= 2
@@ -99,6 +105,7 @@ class DownsamplingProcessorTest(unittest.TestCase):
         pipeline.add_processor(processor)
         pipeline.add_sink(sink_1)
         pipeline.add_sink(sink_0)
+
         # (3) ...and connect the modules
         pipeline.connect(source, sink_0)
         pipeline.connect(source, processor)
@@ -109,6 +116,8 @@ class DownsamplingProcessorTest(unittest.TestCase):
         sleep(2)
         pipeline.stop()
         pipeline.join()
+
+        sleep(0.1)  # To make this work under macOS in the cloud
 
         # Assert
         self.assertEqual(sink_0.queue.qsize(), 10)


### PR DESCRIPTION
Use the xvfb fixture under Linux and macOS, only. Under Windows skip it all together.

This should make these tests succeed under Linux and macOS locally as well as in the cloud, and under Windows at least locally.

This should fix #48 for local (not in the cloud) runs.