### PR TITLE
Introduce `add_connection` method to `GraphPipeline`

### DIFF
--- a/multisensor_pipeline/pipeline/graph.py
+++ b/multisensor_pipeline/pipeline/graph.py
@@ -44,6 +44,29 @@ class GraphPipeline(PipelineBase):
         module.add_observer(successor)  # must be first, because it implicitly validates the connection
         self._graph.add_edge(module, successor)
 
+    def add_connection(
+        self,
+        module,
+        successor,
+    ):
+        """
+        Add a connection from the given source to the given sink.
+
+        This is a convenience method wrapping two add and one connect call.
+        This method automatically adds the given modules to the pipeline.
+        So, explicit calls to `add` are not necessary for the given modules.
+        """
+        # Add the modules
+        # Note that nodes get added to networkx' DiGraph by their hash.
+        # This makes the adding method idempotent.
+        # So, adding the same node twice has the same effect as adding it once.
+        # Therefore, the following works, regardless of the number of calls.
+        self.add(module)
+        self.add(successor)
+
+        # Connect the modules
+        self.connect(module, successor)
+
     def get_nodes_with_attribute(self, attribute, value):
         return [node[0] for node in self._graph.nodes(data=attribute) if node[1] == value]
 


### PR DESCRIPTION
This adds the `add_connection` method to the `GraphPipeline` class. It adds a connection of two nodes and the nodes themselves implicitly. This can help with usability, as it is less error-prone than programming these two steps by hand when creating a pipeline. Also, this allows for considerably shorter pipeline definitions, which helps the readability of the documentation.

Using `add` and `connect`:

```python
pipeline = GraphPipeline()
pipeline.add([
    eyetracking_source,
    imagecropping_processor,
    imageclassification_processor,
    video_vis_sink
])
pipeline.connect(eyetracking_source, imagecropping_processor)
pipeline.connect(eyetracking_source, video_vis_sink)
pipeline.connect(imagecropping_processor, imageclassification_processor)
pipeline.connect(imageclassification_processor, video_vis_sink)
```

Using `add_connection`:

```python
pipeline = Pipeline()
pipeline.add_connection(eye_tracking_source, image_cropping_processor)
pipeline.add_connection(eye_tracking_source, video_visualizer_sink)
pipeline.add_connection(image_cropping_processor, image_classifier_processor)
pipeline.add_connection(image_classifier_processor, video_visualizer_sink)
```