### PR TITLE
Introduce a context manager to `GraphPipeline`

### DIFF
--- a/multisensor_pipeline/pipeline/graph.py
+++ b/multisensor_pipeline/pipeline/graph.py
@@ -126,6 +126,13 @@ class GraphPipeline(PipelineBase):
         for node in self.sink_nodes:
             node.join()
 
+    def __enter__(self):
+        self.start()
+
+    def __exit__(self, type, value, traceback):
+        self.stop()
+        self.join()
+
 
 class SubGraphPipeline(GraphPipeline, BaseProcessor):
     """ A pipeline that can be used like a BaseProcessor """

--- a/multisensor_pipeline/tests/test_pipeline.py
+++ b/multisensor_pipeline/tests/test_pipeline.py
@@ -1,0 +1,106 @@
+from time import sleep
+
+from pytest import fixture, raises
+
+from multisensor_pipeline.modules.base.base import BaseSource, BaseSink
+from multisensor_pipeline.pipeline.graph import GraphPipeline
+
+
+@fixture
+def pipeline():
+    pipeline: GraphPipeline = GraphPipeline()
+
+    return pipeline
+
+
+class SourceModule(BaseSource):
+    pass
+
+
+class SinkModule(BaseSink):
+    pass
+
+
+def test_pipeline(pipeline):
+    # Mock
+    source_module: SourceModule = SourceModule()
+    sink_module: SinkModule = SinkModule()
+    pipeline.add(modules=[source_module, sink_module])
+    pipeline.connect(module=source_module, successor=sink_module)
+
+    # Test
+    with pipeline:
+        sleep(0.001)
+
+    # Assert
+    assert True  # If we get here, we consider that a success
+
+
+def test_pipeline_manual_start(pipeline):
+    # Mock
+    source_module: SourceModule = SourceModule()
+    sink_module: SinkModule = SinkModule()
+    pipeline.add(modules=[source_module, sink_module])
+    pipeline.connect(module=source_module, successor=sink_module)
+
+    # Test
+    with raises(expected_exception=RuntimeError):
+        with pipeline:
+            pipeline.start()
+
+            sleep(0.001)
+
+    # Assert
+    assert True  # If we get here, we consider that a success
+
+
+def test_pipeline_manual_stop(pipeline):
+    # Mock
+    source_module: SourceModule = SourceModule()
+    sink_module: SinkModule = SinkModule()
+    pipeline.add(modules=[source_module, sink_module])
+    pipeline.connect(module=source_module, successor=sink_module)
+
+    # Test
+    with pipeline:
+        sleep(0.001)
+
+    pipeline.stop()
+
+    # Assert
+    assert True  # If we get here, we consider that a success
+
+
+def test_pipeline_manual_stop_and_join(pipeline):
+    # Mock
+    source_module: SourceModule = SourceModule()
+    sink_module: SinkModule = SinkModule()
+    pipeline.add(modules=[source_module, sink_module])
+    pipeline.connect(module=source_module, successor=sink_module)
+
+    # Test
+    with pipeline:
+        sleep(0.001)
+
+    pipeline.stop()
+    pipeline.join()
+
+    # Assert
+    assert True  # If we get here, we consider that a success
+
+
+def test_pipeline_manual_join(pipeline):
+    # Mock
+    source_module: SourceModule = SourceModule()
+    sink_module: SinkModule = SinkModule()
+    pipeline.add(modules=[source_module, sink_module])
+    pipeline.connect(module=source_module, successor=sink_module)
+
+    # Test
+    with pipeline:
+        sleep(0.001)
+
+    pipeline.join()
+
+    # Assert
+    assert True  # If we get here, we consider that a success


### PR DESCRIPTION
This adds context manager functionality to the `GraphPipeline` class. The context manager handles starting, stopping and joining the pipeline in an automated manner. This increases usability, as using the context manager is less error-prone than users programming the `start`, `stop` and `join` calls themselves. This also leads to shorter pipeline definitions, which increases the readability of the documentation:

Without the context manager:

```python
pipeline.start()
sleep(5)
pipeline.stop()
pipeline.join()
```

With the context manager:

```python
with pipeline:
    sleep(5)
```